### PR TITLE
更新 101 年和 102 年的考古題連結

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@
 
 - 101
     - [101台大資工推甄第二階段](http://lyingheart6174.pixnet.net/blog/post/5121469) 由 老王不老(lyingheart6174) 整理
-    - [http://guidance.tnfsh.tn.edu.tw/ezfiles/7/1007/img/42/101J02.pdf](http://guidance.tnfsh.tn.edu.tw/ezfiles/7/1007/img/42/101J02.pdf)（101學年度） 由 藍挺瑋 還原
+    - [https://www.tfcis.org/~lantw44/download/exam/entrance/ntu-csie-math.pdf](https://www.tfcis.org/~lantw44/download/exam/entrance/ntu-csie-math.pdf)（101學年度） 由 藍挺瑋 還原
 
 - 102
     - [[心得] 台大資工數學筆試](https://www.ptt.cc/bbs/SENIORHIGH/M.1364712123.A.BBA.html)（不完全）（102學年度） 由 teresacream (奶油) 還原
-    - [https://guidance.tnfsh.tn.edu.tw/ezfiles/7/1007/img/85/J03.pdf](https://guidance.tnfsh.tn.edu.tw/ezfiles/7/1007/img/85/J03.pdf)（102學年度） 由 江韋霖 還原
+    - [[心得] 台大資工上機試題](https://www.ptt.cc/bbs/SENIORHIGH/M.1365001949.A.F90.html)（102學年度） 由 江韋霖 還原
 
 - 103
     - [[心得] 台大資工 數學筆試](https://www.ptt.cc/bbs/SENIORHIGH/M.1396156101.A.6E9.html)（103學年度） 由 weirdfoot (ユニライト) 還原


### PR DESCRIPTION
臺南一中輔導室連結失效，原有檔案移入 Google 雲端硬碟，只能使用校內帳號登
入，不對外開放。因此將 101 年連結改指向我的個人網頁、102 年改指向 PTT。